### PR TITLE
Revert "bump 1.65.2 -> 1.67.0"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
-VERSION=v1.67.0
+VERSION=v1.65.2
 git clone https://github.com/rclone/rclone.git
 (
     cd rclone &&


### PR DESCRIPTION
This reverts commit 9edbfb587ae08f7dbbc1777bd0edd252d1e55f5b. This is failing in our environment because we have an older version of golang. When I built this on my builder, it worked because I have a different golang version. Revert it for now.