### PR TITLE
NAS-130370 / 24.10 / Bump rclone for fixing CVE

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -ex
-VERSION=v1.65.2
+VERSION=v1.67.0
+
+# We specify netcgo tag because it is required if we want to use nscd
 git clone https://github.com/rclone/rclone.git
 (
     cd rclone &&

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-rclone (1.56.1-1) unstable; urgency=medium
+rclone (1.67.0) unstable; urgency=medium
 
   * Initial release (Closes: #1)
 


### PR DESCRIPTION
This PR adds changes to not build rclone anymore and instead just download it from upstream and also makes rclone man available for consumption.