### PR TITLE
Add support for aarch64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.4.0
 Homepage: https://min.io
 
 Package: rclone
-Architecture: amd64
+Architecture: amd64 arm64
 Depends: python3
 Description: Rclone syncs your files to cloud storage
  Rclone is a command line program to manage files on cloud storage.


### PR DESCRIPTION
After the good [community response](https://forums.truenas.com/t/truenas-on-arm-now-available/49160) to my [unofficial release TrueNAS on ARM](https://forums.truenas.com/t/truenas-on-arm-processors-early-builds-available-now-truenas-tech-talk-t3-e037/50785), I've heard that my contributions may be welcomed upstream.

Out of my [general roadmap](https://github.com/joel0-truenas/truenas-on-arm/blob/main/changes.md), I'm starting with the simple one-line changes for packages that already support aarch64, but are just missing package metadata.  `rclone` is one of these packages.