### PR TITLE
NAS-141373 / 27.0.0-BETA.1 / Bump rclone to v1.74.3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
-VERSION=v1.74.1
+VERSION=v1.74.2
 
 # We specify netcgo tag because it is required if we want to use nscd
 git clone https://github.com/rclone/rclone.git

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
-VERSION=v1.74.2
+VERSION=v1.74.3
 
 # We specify netcgo tag because it is required if we want to use nscd
 git clone https://github.com/rclone/rclone.git

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
-VERSION=v1.72.1
+VERSION=v1.74.1
 
 # We specify netcgo tag because it is required if we want to use nscd
 git clone https://github.com/rclone/rclone.git


### PR DESCRIPTION
## Summary

Update bundled rclone to v1.74.3.

This includes important Proton Drive fixes and stability improvements introduced in >=v1.74.0.

## Changes

- Update rclone to v1.74.3
- Include latest Proton Drive compatibility fixes

## References

Fixes #16

Changelog:
- https://rclone.org/changelog